### PR TITLE
build: add flex to apt-get packages

### DIFF
--- a/README.org
+++ b/README.org
@@ -19,7 +19,7 @@
    command should install these on a Debian/Ubuntu system:
 
    #+begin_example
-apt-get install build-essential libreadline-dev autoconf-archive libgmp-dev expect
+apt-get install build-essential libreadline-dev autoconf-archive libgmp-dev expect flex
    #+end_example
 
 ** Installation


### PR DESCRIPTION
flex is required to build bic, and is not a dependecy of the other
packages.