### PR TITLE
update flex url.

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@
    - [[https://gmplib.org/][GNU MP]]
 
    To build BIC, you'll need:
-   - [[https://www.gnu.org/software/flex/][GNU Flex]]
+   - [[https://github.com/westes/flex][Flex]]
    - [[https://www.gnu.org/software/bison/][GNU Bison]]
    - [[https://www.gnu.org/software/automake/][GNU Automake]]
    - [[https://www.gnu.org/software/m4/][GNU M4]]


### PR DESCRIPTION
Flex is not a GNU project, and never has been. Therefore, referring to
it as if it were is incorrect. Additionally, update the link to point
to the github repository for flex, rather than the gnu.org page which
just pointed to the github page anyway.