### PR TITLE
Clear message for cscript when the input file is missing.

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,14 +81,7 @@ BIC>
     program:
 
     #+begin_src C
- #include <stdio.h>
-
-int main()
-{
-    FILE *f = fopen("out.txt", "w");
-    fputs("Hello, world!\n", f);
-    return 0;
-}
+#+INCLUDE: "doc/example-scripts/fputs.example"
     #+end_src
 
     We can do this on the REPL with BIC using the following commands:

--- a/doc/example-scripts/fputs.example
+++ b/doc/example-scripts/fputs.example
@@ -1,0 +1,6 @@
+BIC> #include <stdio.h>
+BIC> FILE *f;
+f
+BIC> f = fopen("test.txt", "a");
+0x562c188c2d40
+BIC> 

--- a/src/c.lang
+++ b/src/c.lang
@@ -220,6 +220,7 @@
 (deftype E_CTX "Evaluator Context" "tECTX"
          ("ID_MAP" "STRUCT_ID_MAP" "UNION_ID_MAP" "PARENT_CTX" "ALLOC_CHAIN" "NAME" "RETVAL"
           ("JMP_BUF" jmp_buf)
+          ("SHOULD_BREAK" flag)
           ("IS_FN_CALL" flag)
           ("IS_STATIC" flag)))
 

--- a/src/cscript.c
+++ b/src/cscript.c
@@ -183,7 +183,7 @@ static tree __evaluate_cscript(tree head, const char *fname, int argc,
     if (has_main)
         add_call_to_main(head, num_main_args);
 
-    return evaluate(head, fname);
+    evaluate(head, fname);
 }
 
 void cscript_exit(tree result)
@@ -218,8 +218,5 @@ int evaluate_cscript(const char *script_name,
 
   return_val = __evaluate_cscript(cscript_parse_head, script_name, argc, argv);
 
-  if (!return_val)
-    return 0;
-
-  return get_c_main_return_value(return_val);
+  return 0;
 }

--- a/src/cscript.c
+++ b/src/cscript.c
@@ -5,8 +5,8 @@
 #include "gc.h"
 #include "tree-dump.h"
 #include "tree-dump-dot.h"
-#include <sys/stat.h>
 #include <string.h>
+#include <unistd.h>
 
 extern FILE *cscriptin;
 extern const char* cscript_current_file;
@@ -30,8 +30,7 @@ static int parse_cscript(const char *fname)
     int parse_result;
     FILE *f;
     char *command;
-    struct stat st;
-    if (stat(fname, &st) < 0) {
+    if (access(fname, F_OK)) {
         fprintf(stderr, "File not found: %s\n", fname);
         return 1;
     }

--- a/src/cscript.c
+++ b/src/cscript.c
@@ -30,8 +30,9 @@ static int parse_cscript(const char *fname)
     int parse_result;
     FILE *f;
     char *command;
+
     if (access(fname, F_OK)) {
-        fprintf(stderr, "File not found: %s\n", fname);
+        fprintf(stderr, "Error, file not found: %s\n", fname);
         return 1;
     }
     asprintf(&command, "gcc -x c -E " EXTRA_CPP_OPTS " \"%s\"", fname);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1997,11 +1997,12 @@ static tree eval_loop_for(tree t, int depth)
             break;
 
         push_ctx("For Loop");
-        tree ret = __evaluate(tFLOOP_STMTS(t), depth + 1);
-        pop_ctx();
+        __evaluate(tFLOOP_STMTS(t), depth + 1);
 
-        if (is_T_BREAK(ret))
+        if (tECTX_SHOULD_BREAK(cur_ctx))
             return NULL;
+
+        pop_ctx();
 
         __evaluate_1(tFLOOP_AFTER(t), depth + 1);
 
@@ -2026,11 +2027,12 @@ static tree eval_loop_while(tree t, int depth)
             break;
 
         push_ctx("While Loop");
-        tree ret = __evaluate(tWLOOP_STMTS(t), depth + 1);
-        pop_ctx();
+        __evaluate(tWLOOP_STMTS(t), depth + 1);
 
-        if (is_T_BREAK(ret))
+        if (tECTX_SHOULD_BREAK(cur_ctx))
             return NULL;
+
+        pop_ctx();
 
     } while (1);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1693,6 +1693,13 @@ static tree eval_gteq(tree t, int depth)
     return ret;
 }
 
+static tree eval_break(tree t, int depth)
+{
+    tECTX_SHOULD_BREAK(cur_ctx) = true;
+
+    return t;
+}
+
 static tree eval_eq(tree t, int depth)
 {
     tree left = convert_to_comparable_type(tEQ_LHS(t), depth),
@@ -2672,7 +2679,7 @@ static tree __evaluate_1(tree t, int depth)
     case T_INFIX:      result = eval_infix(t, depth + 1);      break;
     case T_IF:         result = eval_if(t, depth + 1);         break;
     case T_RETURN:     result = eval_return(t, depth + 1);     break;
-    case T_BREAK:      result = t;                             break;
+    case T_BREAK:      result = eval_break(t, depth + 1);      break;
     case T_DECL_COMPOUND:result = eval_decl_compound(t, depth + 1);break;
     case T_ENUMERATOR: result = eval_enumerator(t, depth + 1); break;
     case T_SIZEOF:     result = eval_sizeof(t, depth + 1);     break;

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -96,8 +96,13 @@ static void *track_alloc(void *ptr)
 
 static void ctx_backtrace(void)
 {
-    fprintf(stderr, "Evaluator Backtrace\n===================\n");
-    tree_dump(cur_ctx);
+    fprintf(stderr, "Evaluator Backtrace:\n");
+    tree ctx = cur_ctx;
+
+    while (ctx) {
+        puts(tID_STR(tECTX_NAME(ctx)));
+        ctx = tECTX_PARENT_CTX(ctx);
+    }
 }
 
 void __attribute__((noreturn)) eval_die(tree t, const char *format, ...)

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -43,7 +43,7 @@ const tree get_include_chain(void)
 static const char *current_filename;
 
 static tree __evaluate_1(tree t, int depth);
-static tree __evaluate(tree t, int depth);
+static void __evaluate(tree t, int depth);
 
 enum identifier_search_scope
 {
@@ -2708,18 +2708,18 @@ static tree __evaluate_1(tree t, int depth)
     return result;
 }
 
-static tree __evaluate(tree head, int depth)
+static void __evaluate(tree head, int depth)
 {
-    tree result, i;
+    tree i;
 
     if (!head)
-        return NULL;
+        return;
 
     if (!is_CHAIN_HEAD(head))
-        return __evaluate_1(head, depth);
+        __evaluate_1(head, depth);
 
     for_each_tree(i, head) {
-        result = __evaluate_1(i, depth);
+        tree result = __evaluate_1(i, depth);
 
         if (is_T_RETURN(result)) {
             tree fn_ctx = cur_ctx;
@@ -2739,10 +2739,8 @@ static tree __evaluate(tree head, int depth)
         }
 
         if (is_T_BREAK(result))
-            return result;
+            return;
     }
-
-    return result;
 }
 
 int get_c_main_return_value(tree t)
@@ -2758,10 +2756,10 @@ int get_c_main_return_value(tree t)
     return ret;
 }
 
-tree evaluate(tree t, const char *fname)
+void evaluate(tree t, const char *fname)
 {
     current_filename = fname;
-    return __evaluate(t, 0);
+    __evaluate(t, 0);
 }
 
 tree evaluate_expr(tree t)

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -2762,6 +2762,11 @@ tree evaluate(tree t, const char *fname)
     return __evaluate(t, 0);
 }
 
+tree evaluate_expr(tree t)
+{
+    return __evaluate_1(t, 0);
+}
+
 static tree handle_builtin_strcpy_chk(tree args)
 {
     /* Transform into a normal call to strcpy, stripping off the last argument.

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -18,4 +18,5 @@ void __attribute__((noreturn)) eval_die(tree t, const char *format, ...);
 tree find_global_identifiers(const char *prefix);
 int get_c_main_return_value(tree t);
 tree evaluate(tree t, const char *filename);
+tree evaluate_expr(tree t);
 void eval_init(void);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -17,6 +17,6 @@ const tree get_include_chain(void);
 void __attribute__((noreturn)) eval_die(tree t, const char *format, ...);
 tree find_global_identifiers(const char *prefix);
 int get_c_main_return_value(tree t);
-tree evaluate(tree t, const char *filename);
+void evaluate(tree t, const char *filename);
 tree evaluate_expr(tree t);
 void eval_init(void);

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -20,7 +20,7 @@ static void print_sizeof_object(tree inspect_id,
 
     tSZOF_EXP(sizeof_obj) = resolved_object;
 
-    sizeof_result = evaluate(sizeof_obj, "<inspector>");
+    sizeof_result = evaluate_expr(sizeof_obj);
 
     printf("sizeof(%s) = ", tID_STR(inspect_id));
     pretty_print(sizeof_result);

--- a/src/repl.c
+++ b/src/repl.c
@@ -128,7 +128,7 @@ static tree get_compound_completion_object(struct completion_comp_access comp_ac
     if (parse_result)
         return NULL;
 
-    return evaluate(repl_parse_head, "<completion>");
+    return evaluate_expr(repl_parse_head);
 }
 
 void match_identifiers_for_idmap(tree chain, tree idmap,
@@ -466,7 +466,7 @@ void bic_repl()
 
             add_history(line);
 
-            result = evaluate(parsed_line, "<stdin>");
+            result = evaluate_expr(parsed_line);
 
             if (result) {
                 pretty_print(result);


### PR DESCRIPTION
This makes sure the input file exists before parsing it. The original error message for missing files looked like this:
```
gcc: error: deleteme.c: No such file or directory
gcc: warning: ‘-x c’ after last input file has no effect
gcc: fatal error: no input files
compilation terminated.
Parser Error: deleteme.c:1 syntax error, unexpected $end.
```

..which kinda confuses the issue (having `gcc` report the error instead of `bic`).

Now it looks like this:
```
File not found: nonexistent.c
```
