### PR TITLE
Aarch64 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ os:
   - linux
   - osx
 
+arch:
+  - amd64
+  - arm64
+
+jobs:
+  exclude:
+    os: osx
+    arch: arm64
+
 language: c
 
 addons:
@@ -15,6 +24,7 @@ addons:
       - expect
       - bison
       - flex
+      - libltdl-dev
   homebrew:
     packages:
       - autoconf-archive

--- a/src/aarch64/Makefile.am
+++ b/src/aarch64/Makefile.am
@@ -1,6 +1,6 @@
 noinst_LIBRARIES = libbic_aarch64.a
 
 libbic_aarch64_a_SOURCES = function_call.c function_call.h ptr_call.c	\
-                           ptr_call.h do_call.S
+                           ptr_call.h do_call.S ptr_call_entry.S
 
 libbic_aarch64_a_CFLAGS = -I$(top_builddir)/src

--- a/src/aarch64/function_call.c
+++ b/src/aarch64/function_call.c
@@ -1,4 +1,3 @@
-#include <gc.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/aarch64/ptr_call.c
+++ b/src/aarch64/ptr_call.c
@@ -2,7 +2,12 @@
 #include <stdlib.h>
 
 #include "../evaluate.h"
+#include "../spec-resolver.h"
 #include "ptr_call.h"
+
+extern void entry_point_0(void);
+extern void entry_point_1(void);
+extern void entry_point_end(void);
 
 struct ptr_map {
     void *entry_addr;
@@ -10,12 +15,103 @@ struct ptr_map {
     struct ptr_map *next;
 };
 
+static struct ptr_map *ptr_call_map = NULL;
+static void *next_entry_point = &entry_point_0;
+
 void *get_entry_point_for_fn(tree fndef)
 {
-    return NULL;
+    ptrdiff_t entry_point_delta = &entry_point_1 - &entry_point_0;
+    void *entry_point_end = &entry_point_end;
+    struct ptr_map *new_map = malloc(sizeof(*new_map));
+    void *entry_addr = next_entry_point;
+
+    if (next_entry_point > entry_point_end) {
+        eval_die(fndef, "can not take address of function,"
+                 "entry points exhausted.\n");
+    }
+
+    new_map->entry_addr = entry_addr;
+    new_map->fndef = fndef;
+    new_map->next = ptr_call_map;
+    ptr_call_map = new_map;
+
+    next_entry_point += entry_point_delta;
+
+    return entry_addr;
 }
 
-ptrdiff_t handle_ptr_call(struct argregs *regs)
+tree resolve_fn_call(void *entry_addr)
 {
+    struct ptr_map *cur_map = ptr_call_map;
+
+    while (cur_map) {
+        if (cur_map->entry_addr == entry_addr)
+            return cur_map->fndef;
+
+        cur_map = cur_map->next;
+    }
+
+    fprintf(stderr, "Error: could not resolve function for entry point %p\n",
+            entry_addr);
+
+    exit(1);
+}
+
+static tree get_argument_chain(tree fndef, struct argregs *regs)
+{
+    int integer_idx = 0;
+    tree ret, arg, args = tFN_ARGS(fndef);
+
+    if (!args)
+        return NULL;
+
+    ret = tree_make(CHAIN_HEAD);
+
+    for_each_tree(arg, args) {
+        tree argType = resolve_decl_specs_to_type(tDECL_SPECS(arg)),
+            decl = tDECL_DECLS(arg),
+            new_arg;
+
+        resolve_ptr_type(&decl, &argType);
+
+        switch (TYPE(argType)) {
+#define CREATE_INT_ARG(type, mpz_func, ctype)                           \
+            case type:                                                  \
+                new_arg = tree_make(T_INTEGER);                         \
+                mpz_func (tINT_VAL(new_arg),                                \
+                          (ctype) regs->iarg[integer_idx]);             \
+                integer_idx++;                                          \
+                break;
+            CREATE_INT_ARG(D_T_CHAR, mpz_init_set_si, char);
+            CREATE_INT_ARG(D_T_SHORT, mpz_init_set_si, short);
+            CREATE_INT_ARG(D_T_INT, mpz_init_set_si, int);
+            CREATE_INT_ARG(D_T_LONG, mpz_init_set_si, long);
+            CREATE_INT_ARG(D_T_LONGLONG, mpz_init_set_si, long long);
+            CREATE_INT_ARG(D_T_UCHAR, mpz_init_set_ui, unsigned char);
+            CREATE_INT_ARG(D_T_USHORT, mpz_init_set_ui, unsigned short);
+            CREATE_INT_ARG(D_T_UINT, mpz_init_set_ui, unsigned int);
+            CREATE_INT_ARG(D_T_ULONG, mpz_init_set_ui, unsigned long);
+            CREATE_INT_ARG(D_T_ULONGLONG, mpz_init_set_ui, unsigned long long);
+            CREATE_INT_ARG(D_T_PTR, mpz_init_set_ui, ptrdiff_t);
+        default:
+            eval_die(arg, "unknown parameter type in pointer call\n");
+        }
+
+        tree_chain(new_arg, ret);
+    }
+
+    return ret;
+}
+
+ptrdiff_t handle_ptr_call(struct argregs *regs, void *pc)
+{
+    tree fndef = resolve_fn_call(pc),
+        fncall = tree_make(T_FN_CALL);
+
+    tFNCALL_ID(fncall) = tFN_DECL(fndef);
+    tFNCALL_ARGS(fncall) = get_argument_chain(fndef, regs);
+
+    evaluate(fncall, "<PTR>");
+
     return 0;
 }

--- a/src/aarch64/ptr_call.h
+++ b/src/aarch64/ptr_call.h
@@ -5,8 +5,7 @@
 struct argregs
 {
     ptrdiff_t iarg[6];
-    ptrdiff_t pc;
 };
 
-ptrdiff_t handle_ptr_call(struct argregs *regs);
+ptrdiff_t handle_ptr_call(struct argregs *regs, void *pc);
 void *get_entry_point_for_fn(tree fndef);

--- a/src/aarch64/ptr_call_entry.S
+++ b/src/aarch64/ptr_call_entry.S
@@ -1,0 +1,64 @@
+#include "../../config.h"
+
+	.text
+ptr_call_handler:
+
+  stp x29, x30, [sp, #-0x50]!
+	stp	x6, x7, [sp, #0x40]
+	stp	x4, x5, [sp, #0x30]
+	stp	x2, x3, [sp, #0x20]
+	stp	x0, x1, [sp, #0x10]
+
+	add	x0, sp, #0x10
+  mov x1, x9
+	bl	handle_ptr_call
+  ldp x29, x30, [sp], #0x50
+	ret
+
+	.macro	entry_point number
+
+	.global	entry_point_\number
+entry_point_\number:
+	stp 	x29, x30, [sp, #-0x20]!
+  str 	x9, [sp]
+  mov 	x29, sp
+	ldr 	x9, #=entry_point_\number
+	bl   	ptr_call_handler
+  ldr   x9, [sp]
+  ldp   x20, x30, [sp], #0x20
+	ret
+	.endm
+
+	entry_point	0
+	entry_point	1
+	entry_point	2
+	entry_point	3
+	entry_point	4
+	entry_point	5
+	entry_point	6
+	entry_point	7
+	entry_point	8
+	entry_point	9
+	entry_point	10
+	entry_point	11
+	entry_point	12
+	entry_point	13
+	entry_point	14
+	entry_point	15
+	entry_point	16
+	entry_point	17
+	entry_point	18
+	entry_point	19
+	entry_point	20
+	entry_point	21
+	entry_point	22
+	entry_point	23
+	entry_point	24
+	entry_point	25
+	entry_point	26
+	entry_point	27
+	entry_point	28
+	entry_point	29
+	entry_point	30
+	entry_point	31
+	entry_point	end

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -2571,7 +2571,9 @@ static tree eval_cpp_include(tree t, int depth)
 
     reset_include_typenames();
     typename_set_include_file();
+    inhibit_gc();
     ret = cscriptparse();
+    enable_gc();
     typename_unset_include_file();
 
     fclose(out_file_stream);

--- a/src/repl.c
+++ b/src/repl.c
@@ -122,7 +122,9 @@ static tree get_compound_completion_object(struct completion_comp_access comp_ac
     comp_obj_expr = concat_strings(comp_obj_expr, ";");
 
     YY_BUFFER_STATE lex_buffer = repl_scan_string(comp_obj_expr);
+    inhibit_gc();
     int parse_result = replparse();
+    enable_gc();
     repl_delete_buffer(lex_buffer);
 
     if (parse_result)
@@ -373,7 +375,9 @@ static tree repl_do_parse(char *line)
     tree i, ret = NULL;
 
     YY_BUFFER_STATE buffer = repl_scan_string(line);
+    inhibit_gc();
     parse_result = replparse();
+    enable_gc();
     repl_delete_buffer(buffer);
 
     if (parse_result)


### PR DESCRIPTION
Adds pointer call support for AArch64.  This allows the testsuite to pass against this architecture and so add it to CI.